### PR TITLE
Added CI step to tag merge commits with the version number

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       - check-copyright
       - lint
       - tests
-    # if: github.ref_name == 'main'
+    if: github.ref_name == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
@@ -80,28 +80,24 @@ jobs:
         run: pip install -e .
       - name: Figure out current version
         run: python -c 'import benchalerts; print(f"VERSION={benchalerts.__version__}")' >> $GITHUB_ENV
-      - name: Create tag
+      - name: Create or update the git tag with this version
         uses: actions/github-script@v6
         with:
           script: |
             try {
-              console.log('trying');
               await github.rest.git.createRef({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 ref: 'refs/tags/${{ env.VERSION }}',
-                sha: '${{ github.event.pull_request.head.sha }}'
+                sha: context.sha
               });
-              console.log('success');
             } catch (error) {
-              console.log('error:');
               console.log(error);
-              console.log('trying update');
+              console.log('Error creating a ref; will try to update it instead');
               await github.rest.git.updateRef({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 ref: 'tags/${{ env.VERSION }}',
-                sha: '${{ github.event.pull_request.head.sha }}'
+                sha: context.sha
               });
-              console.log('update success');
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,18 +90,18 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 ref: 'refs/tags/${{ env.VERSION }}',
-                sha: context.sha
+                sha: ${{ github.event.pull_request.head.sha }}
               });
               console.log('success');
             } catch (error) {
-              console.log('error');
+              console.log('error:');
               console.log(error);
+              console.log('trying update');
               await github.rest.git.updateRef({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 ref: 'refs/tags/${{ env.VERSION }}',
-                sha: context.sha,
-                force: true
+                sha: ${{ github.event.pull_request.head.sha }}
               });
               console.log('update success');
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,8 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 ref: 'refs/tags/${{ env.VERSION }}',
-                sha: context.sha
+                sha: context.sha,
+                force: true
               });
               console.log('update success');
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
               await github.rest.git.updateRef({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                ref: 'refs/tags/${{ env.VERSION }}',
+                ref: 'tags/${{ env.VERSION }}',
                 sha: '${{ github.event.pull_request.head.sha }}'
               });
               console.log('update success');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       - check-copyright
       - lint
       - tests
-    if: github.ref_name == 'main'
+    # if: github.ref_name == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
@@ -92,12 +92,9 @@ jobs:
                 sha: context.sha
               });
             } catch (error) {
-              console.log(error);
-              console.log('Error creating a ref; will try to update it instead');
-              await github.rest.git.updateRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: 'tags/${{ env.VERSION }}',
-                sha: context.sha
-              });
+              if (error.response.data.message == 'Reference already exists') {
+                console.log('Tag already existed; doing nothing');
+              } else {
+                throw error;
+              }
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       - check-copyright
       - lint
       - tests
-    # if: github.ref_name == 'main'
+    if: github.ref_name == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 ref: 'refs/tags/${{ env.VERSION }}',
-                sha: ${{ github.event.pull_request.head.sha }}
+                sha: '${{ github.event.pull_request.head.sha }}'
               });
               console.log('success');
             } catch (error) {
@@ -101,7 +101,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 ref: 'refs/tags/${{ env.VERSION }}',
-                sha: ${{ github.event.pull_request.head.sha }}
+                sha: '${{ github.event.pull_request.head.sha }}'
               });
               console.log('update success');
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
           script: |
             try {
               console.log('trying');
-              github.rest.git.createRef({
+              await github.rest.git.createRef({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 ref: 'refs/tags/${{ env.VERSION }}',
@@ -96,7 +96,7 @@ jobs:
             } catch (error) {
               console.log('error');
               console.log(error);
-              github.rest.git.updateRef({
+              await github.rest.git.updateRef({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 ref: 'refs/tags/${{ env.VERSION }}',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,19 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: 'refs/tags/${{ env.VERSION }}',
-              sha: context.sha
-            })
+            try {
+              github.rest.git.createRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: 'refs/tags/${{ env.VERSION }}',
+                sha: context.sha
+              });
+            } catch (error) {
+              console.log(error);
+              github.rest.git.updateRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: 'refs/tags/${{ env.VERSION }}',
+                sha: context.sha
+              });
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,13 +85,16 @@ jobs:
         with:
           script: |
             try {
+              console.log('trying');
               github.rest.git.createRef({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 ref: 'refs/tags/${{ env.VERSION }}',
                 sha: context.sha
               });
+              console.log('success');
             } catch (error) {
+              console.log('error');
               console.log(error);
               github.rest.git.updateRef({
                 owner: context.repo.owner,
@@ -99,4 +102,5 @@ jobs:
                 ref: 'refs/tags/${{ env.VERSION }}',
                 sha: context.sha
               });
+              console.log('update success');
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,30 @@ jobs:
         run: pip install -e '.[dev]'
       - name: Run tests
         run: pytest -v -rs --log-level=DEBUG tests
+
+  release:
+    needs:
+      - check-copyright
+      - lint
+      - tests
+    # if: github.ref_name == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+      - name: Install package
+        run: pip install -e .
+      - name: Figure out current version
+        run: python -c 'import benchalerts; print(f"VERSION={benchalerts.__version__}")' >> $GITHUB_ENV
+      - name: Create tag
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/${{ env.VERSION }}',
+              sha: context.sha
+            })

--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@
 A package to facilitate automated alerting based on
 [Conbench](https://github.com/conbench/conbench) data.
 
+## Installing
+
+To install the latest version:
+
+    pip install git+https://github.com/conbench/benchalerts.git
+
+To install a specific version (must specify a full MAJOR.MINOR.PATCH version):
+
+    pip install git+https://github.com/conbench/benchalerts.git@0.1.0
+
 ## Contributing
 
 To start, clone the repo, install the editable package, and initialize pre-commit:


### PR DESCRIPTION
This PR adds a quick step to tag this repo's merge commits with whatever the `benchalerts` version number is. This means people will be able to install a specific version doing something like `pip install 
git+https://github.com/conbench/benchalerts.git@0.1.0`.

The tag should always be on the `main` branch. If a PR manually increments the version, then upon merge, a new version tag will be created on the merge commit. Else if the PR doesn't bump the version, that existing version tag will be updated to the merge commit.