### PR TITLE
Fail CI if under coverage threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@
 
 name: ci
 
+env:
+  # Coverage threshold under which to fail the tests step
+  COV_THRESHOLD: 100
+
 on:
   push:
     branches:
@@ -65,7 +69,13 @@ jobs:
       - name: Install package
         run: pip install -e '.[dev]'
       - name: Run tests
-        run: pytest -vv --log-level=DEBUG tests
+        run: |
+          pytest -vv \
+            --log-level DEBUG \
+            --cov benchalerts \
+            --cov-fail-under $COV_THRESHOLD \
+            --cov-report term-missing \
+            tests
 
   release:
     needs:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ To install a specific version (must specify a full MAJOR.MINOR.PATCH version):
 
     pip install git+https://github.com/conbench/benchalerts.git@0.1.0
 
+The latest version is defined in [this file](benchalerts/_version.py).
+
 ## Contributing
 
 To start, clone the repo, install the editable package, and initialize pre-commit:
@@ -24,13 +26,19 @@ To start, clone the repo, install the editable package, and initialize pre-commi
     pip install -e '.[dev]'
     pre-commit install
 
-After making changes, run tests:
+After making changes, run tests. The coverage theshold is defined in the
+[CI yml file](.github/workflows/ci.yml). PRs with a total coverage under this threshold
+will fail the CI build.
 
-    pytest -vv --log-level=DEBUG tests/
+    pytest -vv \
+        --log-level DEBUG \
+        --cov benchalerts \
+        --cov-report term-missing \
+        tests
 
 This will run both unit and integration tests, but integration tests will be skipped if
-the correct environment variables are not set. See `tests/integration_tests/README.md`
-for instructions.
+the correct environment variables are not set. See
+[the integration test README](tests/integration_tests/README.md) for instructions.
 
 Code is linted with `black`, `flake8`, and `isort`. `pre-commit` should automatically
 lint your code before a commit, but you can always lint manually by running

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,3 +14,4 @@
 
 pre-commit
 pytest
+pytest-cov


### PR DESCRIPTION
Fixes #3.

This PR fails the CI `tests` step if test coverage is under a threshold. I set the threshold to 100, our current test coverage.