### PR TITLE
Don't fail if there's no baseline run

### DIFF
--- a/benchalerts/_version.py
+++ b/benchalerts/_version.py
@@ -15,4 +15,4 @@
 
 # Please do not add anything else to this file except __version__
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/benchalerts/workflows.py
+++ b/benchalerts/workflows.py
@@ -115,7 +115,10 @@ def update_github_status_based_on_regressions(
         regressions = benchmarks_with_z_regressions(all_comparisons)
         log.info(f"Found the following regressions: {regressions}")
 
-        if regressions:
+        if not all_comparisons:
+            desc = "Could not find any baseline runs to compare to"
+            state = github.StatusState.SUCCESS
+        elif regressions:
             desc = f"There were {len(regressions)} benchmark regressions in this commit"
             state = github.StatusState.FAILURE
         else:

--- a/tests/integration_tests/test_clients_integration.py
+++ b/tests/integration_tests/test_clients_integration.py
@@ -49,6 +49,12 @@ def test_create_pull_request_comment(github_auth: str):
             1,
             False,
         ),
+        (
+            "https://velox-conbench.voltrondata.run",
+            "b74e7045fade737e39b0f9867bc8b8b23fe00b78",
+            0,
+            False,
+        ),
     ],
 )
 def test_get_comparison_to_baseline(

--- a/tests/unit_tests/mocked_responses/GET_conbench_runs_contender_wo_base.json
+++ b/tests/unit_tests/mocked_responses/GET_conbench_runs_contender_wo_base.json
@@ -1,0 +1,52 @@
+{
+    "status_code": 200,
+    "data": {
+        "commit": {
+            "author_avatar": "https://avatars.githubusercontent.com/u/878798?v=4",
+            "author_login": "dianaclarke",
+            "author_name": "Diana Clarke",
+            "id": "some-commit-uuid-1",
+            "message": "ARROW-11771: [Developer][Archery] Move benchmark tests (so CI runs them)",
+            "parent_sha": "4beb514d071c9beec69b8917b5265e77ade22fb3",
+            "repository": "https://github.com/apache/arrow",
+            "sha": "02addad336ba19a654f9c857ede546331be7b631",
+            "timestamp": "2021-02-25T01:02:51",
+            "url": "https://github.com/apache/arrow/commit/02addad336ba19a654f9c857ede546331be7b631"
+        },
+        "hardware": {
+            "architecture_name": "x86_64",
+            "cpu_core_count": 2,
+            "cpu_frequency_max_hz": 3500000000,
+            "cpu_l1d_cache_bytes": 32768,
+            "cpu_l1i_cache_bytes": 32768,
+            "cpu_l2_cache_bytes": 262144,
+            "cpu_l3_cache_bytes": 4194304,
+            "cpu_model_name": "Intel(R) Core(TM) i7-7567U CPU @ 3.50GHz",
+            "cpu_thread_count": 4,
+            "gpu_count": 2,
+            "gpu_product_names": [
+                "Tesla T4",
+                "GeForce GTX 1060 3GB"
+            ],
+            "id": "some-machine-uuid-1",
+            "kernel_name": "19.6.0",
+            "memory_bytes": 17179869184,
+            "name": "some-machine-name",
+            "os_name": "macOS",
+            "os_version": "10.15.7",
+            "type": "machine"
+        },
+        "has_errors": false,
+        "id": "some_contender",
+        "links": {
+            "baseline": null,
+            "commit": "http://localhost/api/commits/some-commit-uuid-1/",
+            "hardware": "http://localhost/api/hardware/some-machine-uuid-1/",
+            "list": "http://localhost/api/runs/",
+            "self": "http://localhost/api/runs/some-run-uuid-1/"
+        },
+        "name": "some run name",
+        "reason": "some run reason",
+        "timestamp": "2021-02-04T17:22:05.225583"
+    }
+}

--- a/tests/unit_tests/mocked_responses/GET_conbench_runs_sha_no_baseline.json
+++ b/tests/unit_tests/mocked_responses/GET_conbench_runs_sha_no_baseline.json
@@ -1,0 +1,53 @@
+{
+    "status_code": 200,
+    "data": [
+        {
+            "commit": {
+                "author_avatar": "https://avatars.githubusercontent.com/u/878798?v=4",
+                "author_login": "dianaclarke",
+                "author_name": "Diana Clarke",
+                "id": "some-commit-uuid-1",
+                "message": "ARROW-11771: [Developer][Archery] Move benchmark tests (so CI runs them)",
+                "parent_sha": "4beb514d071c9beec69b8917b5265e77ade22fb3",
+                "repository": "https://github.com/apache/arrow",
+                "sha": "02addad336ba19a654f9c857ede546331be7b631",
+                "timestamp": "2021-02-25T01:02:51",
+                "url": "https://github.com/apache/arrow/commit/02addad336ba19a654f9c857ede546331be7b631"
+            },
+            "hardware": {
+                "architecture_name": "x86_64",
+                "cpu_core_count": 2,
+                "cpu_frequency_max_hz": 3500000000,
+                "cpu_l1d_cache_bytes": 32768,
+                "cpu_l1i_cache_bytes": 32768,
+                "cpu_l2_cache_bytes": 262144,
+                "cpu_l3_cache_bytes": 4194304,
+                "cpu_model_name": "Intel(R) Core(TM) i7-7567U CPU @ 3.50GHz",
+                "cpu_thread_count": 4,
+                "gpu_count": 2,
+                "gpu_product_names": [
+                    "Tesla T4",
+                    "GeForce GTX 1060 3GB"
+                ],
+                "id": "some-machine-uuid-1",
+                "kernel_name": "19.6.0",
+                "memory_bytes": 17179869184,
+                "name": "some-machine-name",
+                "os_name": "macOS",
+                "os_version": "10.15.7",
+                "type": "machine"
+            },
+            "has_errors": false,
+            "id": "contender_wo_base",
+            "links": {
+                "commit": "http://localhost/api/commits/some-commit-uuid-1/",
+                "hardware": "http://localhost/api/hardware/some-machine-uuid-1/",
+                "list": "http://localhost/api/runs/",
+                "self": "http://localhost/api/runs/some-run-uuid-1/"
+            },
+            "name": "some run name",
+            "reason": "some run reason",
+            "timestamp": "2021-02-04T17:22:05.225583"
+        }
+    ]
+}

--- a/tests/unit_tests/mocked_responses/POST_github_statuses_no_baseline.json
+++ b/tests/unit_tests/mocked_responses/POST_github_statuses_no_baseline.json
@@ -1,0 +1,35 @@
+{
+    "status_code": 201,
+    "data": {
+        "url": "https://api.github.com/repos/octocat/Hello-World/statuses/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+        "avatar_url": "https://github.com/images/error/hubot_happy.gif",
+        "id": 1,
+        "node_id": "MDY6U3RhdHVzMQ==",
+        "state": "success",
+        "description": "Could not find any baseline runs to compare to",
+        "target_url": "https://ci.example.com/1000/output",
+        "context": "continuous-integration/jenkins",
+        "created_at": "2012-07-20T01:19:13Z",
+        "updated_at": "2012-07-20T01:19:13Z",
+        "creator": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+        }
+    }
+}

--- a/tests/unit_tests/test_clients.py
+++ b/tests/unit_tests/test_clients.py
@@ -104,6 +104,16 @@ class TestConbenchClient:
         with pytest.raises(ValueError, match="runs"):
             self.cb.get_comparison_to_baseline("no_runs")
 
+    def test_comparison_warns_when_no_baseline(
+        self, conbench_env, caplog: LogCaptureFixture
+    ):
+        comparisons, baseline_is_parent = self.cb.get_comparison_to_baseline(
+            "no_baseline"
+        )
+        assert not comparisons
+        assert not baseline_is_parent
+        assert "could not find a baseline run" in caplog.text
+
     @pytest.mark.parametrize("path", ["/error_with_content", "/error_without_content"])
     def test_client_error_handling(self, conbench_env, path, caplog: LogCaptureFixture):
         with pytest.raises(requests.HTTPError, match="404"):

--- a/tests/unit_tests/test_workflows.py
+++ b/tests/unit_tests/test_workflows.py
@@ -42,3 +42,16 @@ def test_update_github_status_based_on_regressions_failure(
 
     with pytest.raises(ValueError, match="not found"):
         flows.update_github_status_based_on_regressions(contender_sha="abc", github=gh)
+
+
+@pytest.mark.parametrize("github_auth", ["pat", "app"], indirect=True)
+def test_update_github_status_based_on_regressions_no_baseline(
+    github_auth, conbench_env
+):
+    gh = GitHubRepoClient("some/repo", adapter=MockAdapter())
+    cb = ConbenchClient(adapter=MockAdapter())
+
+    res = flows.update_github_status_based_on_regressions(
+        contender_sha="no_baseline", github=gh, conbench=cb
+    )
+    assert res["description"] == "Could not find any baseline runs to compare to"


### PR DESCRIPTION
Currently ([example](https://app.circleci.com/pipelines/github/facebookincubator/velox/14676/workflows/b58f7561-7f20-40a0-86b9-2e8a1546c7dd/jobs/89177)) if Conbench doesn't return a baseline run for a given contender run, our workflows will fail because we're expecting a string.

This PR handles that case specially by raising a warning and continuing onwards. If no baselines are found for a given commit, the `update_github_status_based_on_regressions` workflow will succeed with a note saying so.