### PR TITLE
Tidied output of get_comparison_to_baseline()

### DIFF
--- a/benchalerts/talk_to_conbench.py
+++ b/benchalerts/talk_to_conbench.py
@@ -111,6 +111,8 @@ def get_comparison_to_baseline(
 
     Parameters
     ----------
+    conbench
+        A ConbenchClient instance.
     contender_sha
         The commit SHA of the contender commit to compare. Needs to match EXACTLY what
         conbench has stored; typically 40 characters. It can't be a shortened version of

--- a/benchalerts/talk_to_conbench.py
+++ b/benchalerts/talk_to_conbench.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2022, Voltron Data.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from .clients import ConbenchClient
+from .log import fatal_and_log, log
+
+
+@dataclass
+class RunComparison:
+    """Track info about a comparison between a contender run and its baseline. Used for
+    outputting information from get_comparison_to_baseline().
+
+    Parameters
+    ----------
+    contender_info
+        The dict returned from Conbench when hitting /runs/{contender_run_id}. Contains
+        info about the run's ID, commit, errors, links, etc.
+    baseline_info
+        The dict returned from Conbench when hitting /runs/{baseline_run_id}, if a
+        baseline run exists for this contender run. Contains info about the run's ID,
+        commit, errors, links, etc.
+    compare_results
+        The list returned from Conbench when hitting
+        /compare/runs/{baseline_run_id}...{contender_run_id}, if a baseline run exists
+        for this contender run. Contains a comparison for every case run to its
+        baseline, including the statistics and regression analysis.
+    """
+
+    contender_info: dict
+    baseline_info: Optional[dict] = None
+    compare_results: Optional[List[dict]] = None
+
+    @property
+    def baseline_is_parent(self) -> Optional[bool]:
+        """Whether the baseline run is on a commit that's the immediate parent of the
+        contender commit.
+        """
+        if self.baseline_info:
+            return (
+                self.baseline_info["commit"]["sha"]
+                == self.contender_info["commit"]["parent_sha"]
+            )
+
+    @property
+    def contender_link(self) -> str:
+        """The link to the contender run page in the webapp."""
+        return f"{self._app_url}/runs/{self.contender_id}"
+
+    @property
+    def compare_link(self) -> Optional[str]:
+        """The link to the run comparison page in the webapp."""
+        if self._compare_path:
+            # self._compare_path has a leading slash already
+            return f"{self._app_url}{self._compare_path}"
+
+    @property
+    def contender_id(self) -> str:
+        """The contender run_id."""
+        return self.contender_info["id"]
+
+    @property
+    def _baseline_id(self) -> Optional[str]:
+        """The baseline run_id."""
+        if self.baseline_info:
+            return self.baseline_info["id"]
+
+    @property
+    def _app_url(self) -> str:
+        """The base URL to use for links to the webapp."""
+        self_link: str = self.contender_info["links"]["self"]
+        return self_link.rsplit("/api/", 1)[0]
+
+    @property
+    def _compare_path(self) -> Optional[str]:
+        """The API path to get comparisons between the baseline and contender."""
+        if self._baseline_id:
+            return f"/compare/runs/{self._baseline_id}...{self.contender_id}/"
+
+    @property
+    def _baseline_path(self) -> Optional[str]:
+        """The API path to get the baseline info."""
+        baseline_link: Optional[str] = self.contender_info["links"].get("baseline")
+        if baseline_link:
+            return baseline_link.rsplit("/api", 1)[-1]
+
+
+def get_comparison_to_baseline(
+    conbench: ConbenchClient,
+    contender_sha: str,
+    z_score_threshold: Optional[float] = None,
+) -> List[RunComparison]:
+    """Get benchmark comparisons between the given contender commit and its baseline
+    commit.
+
+    The baseline commit is defined by conbench, and it's typically the most recent
+    ancestor of the contender commit that's on the default branch.
+
+    Parameters
+    ----------
+    contender_sha
+        The commit SHA of the contender commit to compare. Needs to match EXACTLY what
+        conbench has stored; typically 40 characters. It can't be a shortened version of
+        the SHA.
+    z_score_threshold
+        The (positive) z-score threshold to send to the conbench compare endpoint.
+        Benchmarks with a z-score more extreme than this threshold will be marked as
+        regressions or improvements in the result. Default is to use whatever conbench
+        uses for default.
+
+    Returns
+    -------
+    List[RunComparison]
+        Information about each run associated with the contender commit, and a
+        comparison to its baseline run if that exists.
+    """
+    out_list = []
+    contender_run_ids = [
+        run["id"] for run in conbench.get("/runs/", params={"sha": contender_sha})
+    ]
+    if not contender_run_ids:
+        fatal_and_log(
+            f"Contender commit '{contender_sha}' doesn't have any runs in conbench."
+        )
+
+    log.info(f"Getting comparisons from {len(contender_run_ids)} run(s)")
+    for run_id in contender_run_ids:
+        run_comparison = RunComparison(contender_info=conbench.get(f"/runs/{run_id}/"))
+
+        if run_comparison._baseline_path:
+            run_comparison.baseline_info = conbench.get(run_comparison._baseline_path)
+
+            compare_params = (
+                {"threshold_z": z_score_threshold} if z_score_threshold else None
+            )
+            run_comparison.compare_results = conbench.get(
+                run_comparison._compare_path, params=compare_params
+            )
+
+        else:
+            log.warning(
+                "Conbench could not find a baseline run for the contender run "
+                f"{run_id}. A baseline run needs to be on the default branch in the "
+                "same repository, with the same hardware and context, and have at "
+                "least one of the same benchmark cases."
+            )
+
+        out_list.append(run_comparison)
+
+    return out_list

--- a/benchalerts/workflows.py
+++ b/benchalerts/workflows.py
@@ -15,7 +15,7 @@
 import os
 from typing import Optional
 
-from .clients import ConbenchClient, GitHubRepoClient
+from .clients import CheckStatus, ConbenchClient, GitHubRepoClient, StatusState
 from .log import log
 from .parse_conbench import (
     _clean,
@@ -24,6 +24,7 @@ from .parse_conbench import (
     regression_details,
     regression_summary,
 )
+from .talk_to_conbench import get_comparison_to_baseline
 
 
 def update_github_status_based_on_regressions(
@@ -107,7 +108,7 @@ def update_github_status_based_on_regressions(
     # mark the task as pending
     update_status(
         description="Finding possible regressions",
-        state=github.StatusState.PENDING,
+        state=StatusState.PENDING,
         details_url=build_url,
     )
 
@@ -115,21 +116,21 @@ def update_github_status_based_on_regressions(
     # If anything in here fails, we can!
     try:
         conbench = conbench or ConbenchClient()
-        comparisons = conbench.get_comparison_to_baseline(
-            contender_sha=contender_sha, z_score_threshold=z_score_threshold
+        comparisons = get_comparison_to_baseline(
+            conbench, contender_sha, z_score_threshold
         )
         regressions = benchmarks_with_z_regressions(comparisons)
         log.info(f"Found the following regressions: {regressions}")
 
         if not any(comparison.baseline_info for comparison in comparisons):
             desc = "Could not find any baseline runs to compare to"
-            state = github.StatusState.SUCCESS
+            state = StatusState.SUCCESS
         elif regressions:
             desc = f"There were {len(regressions)} benchmark regressions in this commit"
-            state = github.StatusState.FAILURE
+            state = StatusState.FAILURE
         else:
             desc = "There were no benchmark regressions in this commit"
-            state = github.StatusState.SUCCESS
+            state = StatusState.SUCCESS
 
         # point to the homepage table filtered to runs of this commit
         url = f"{os.environ['CONBENCH_URL']}/?search={contender_sha}"
@@ -138,7 +139,7 @@ def update_github_status_based_on_regressions(
     except Exception as e:
         update_status(
             description=f"Failed finding regressions: {e}",
-            state=github.StatusState.ERROR,
+            state=StatusState.ERROR,
             details_url=build_url,
         )
         log.error(f"Updated status with error: {e}")
@@ -231,7 +232,7 @@ def update_github_check_based_on_regressions(
 
     # mark the task as pending
     update_check(
-        status=github.CheckStatus.IN_PROGRESS,
+        status=CheckStatus.IN_PROGRESS,
         title="Finding possible regressions",
         summary=f"Analyzing `{contender_sha[:8]}` for regressions...",
         details=None,
@@ -242,8 +243,8 @@ def update_github_check_based_on_regressions(
     # If anything in here fails, we can!
     try:
         conbench = conbench or ConbenchClient()
-        comparisons = conbench.get_comparison_to_baseline(
-            contender_sha=contender_sha, z_score_threshold=z_score_threshold
+        comparisons = get_comparison_to_baseline(
+            conbench, contender_sha, z_score_threshold
         )
         regressions = benchmarks_with_z_regressions(comparisons)
 
@@ -271,7 +272,7 @@ def update_github_check_based_on_regressions(
         )
         details = f"Error: `{repr(e)}`\n\nSee build link below."
         update_check(
-            status=github.CheckStatus.NEUTRAL,
+            status=CheckStatus.NEUTRAL,
             title="Error when finding regressions",
             summary=summary,
             details=details,

--- a/tests/integration_tests/test_clients_integration.py
+++ b/tests/integration_tests/test_clients_integration.py
@@ -16,7 +16,7 @@ import os
 
 import pytest
 
-from benchalerts.clients import ConbenchClient, GitHubRepoClient
+from benchalerts.clients import GitHubRepoClient
 
 
 @pytest.mark.parametrize("github_auth", ["pat", "app"], indirect=True)
@@ -32,46 +32,3 @@ def test_create_pull_request_comment(github_auth: str):
         assert res["user"]["type"] == "User"
     elif github_auth == "app":
         assert res["user"]["type"] == "Bot"
-
-
-@pytest.mark.parametrize(
-    ["conbench_url", "commit", "expected_len", "expected_bip"],
-    [
-        # baseline is parent
-        (
-            "https://conbench.ursa.dev/",
-            "bc7de406564fa7b2bcb9bf055cbaba31ca0ca124",
-            8,
-            True,
-        ),
-        # baseline is not parent
-        (
-            "https://velox-conbench.voltrondata.run",
-            "2319922d288c519baa3bffe59c0bedbcb6c827cd",
-            1,
-            False,
-        ),
-        # no baseline
-        (
-            "https://velox-conbench.voltrondata.run",
-            "b74e7045fade737e39b0f9867bc8b8b23fe00b78",
-            1,
-            None,
-        ),
-    ],
-)
-def test_get_comparison_to_baseline(
-    monkeypatch: pytest.MonkeyPatch, conbench_url, commit, expected_len, expected_bip
-):
-    monkeypatch.setenv("CONBENCH_URL", conbench_url)
-    cb = ConbenchClient()
-    comparisons = cb.get_comparison_to_baseline(commit)
-    assert len(comparisons) == expected_len
-    for comparison in comparisons:
-        assert comparison.baseline_is_parent is expected_bip
-        assert comparison.contender_link
-        assert comparison.contender_id
-        if comparison.compare_info:
-            assert comparison.compare_link
-            for benchmark in comparison.compare_info:
-                assert benchmark["contender_run_id"]

--- a/tests/integration_tests/test_talk_to_conbench_integration.py
+++ b/tests/integration_tests/test_talk_to_conbench_integration.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2022, Voltron Data.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from benchalerts.clients import ConbenchClient
+from benchalerts.talk_to_conbench import get_comparison_to_baseline
+
+
+@pytest.mark.parametrize(
+    ["conbench_url", "commit", "expected_len", "expected_bip"],
+    [
+        # baseline is parent
+        (
+            "https://conbench.ursa.dev/",
+            "bc7de406564fa7b2bcb9bf055cbaba31ca0ca124",
+            8,
+            True,
+        ),
+        # baseline is not parent
+        (
+            "https://velox-conbench.voltrondata.run",
+            "2319922d288c519baa3bffe59c0bedbcb6c827cd",
+            1,
+            False,
+        ),
+        # no baseline
+        (
+            "https://velox-conbench.voltrondata.run",
+            "b74e7045fade737e39b0f9867bc8b8b23fe00b78",
+            1,
+            None,
+        ),
+    ],
+)
+def test_get_comparison_to_baseline(
+    monkeypatch: pytest.MonkeyPatch, conbench_url, commit, expected_len, expected_bip
+):
+    monkeypatch.setenv("CONBENCH_URL", conbench_url)
+    cb = ConbenchClient()
+    comparisons = get_comparison_to_baseline(cb, commit)
+    assert len(comparisons) == expected_len
+    for comparison in comparisons:
+        assert comparison.baseline_is_parent is expected_bip
+        assert comparison.contender_link
+        assert comparison.contender_id
+        if comparison.compare_results:
+            assert comparison.compare_link
+            for benchmark in comparison.compare_results:
+                assert benchmark["contender_run_id"]

--- a/tests/unit_tests/expected_md/summary_regressions_baselineisnotparent.md
+++ b/tests/unit_tests/expected_md/summary_regressions_baselineisnotparent.md
@@ -2,10 +2,10 @@ Contender commit `abc` had 2 regressions compared to its baseline commit.
 
 ### Benchmarks with regressions:
 
-- Run ID [some_contender1](https://conbench/some_baseline1...some_contender1)
+- Run ID [some_contender](http://localhost/compare/runs/some_baseline...some_contender/)
   - `snappy, nyctaxi_sample, parquet, arrow`
 
-- Run ID [some_contender2](https://conbench/some_baseline2...some_contender2)
+- Run ID [some_contender_2](http://localhost/compare/runs/some_baseline_2...some_contender_2/)
   - `snappy, nyctaxi_sample, parquet, arrow`
 
 ### Note

--- a/tests/unit_tests/expected_md/summary_regressions_baselineisparent.md
+++ b/tests/unit_tests/expected_md/summary_regressions_baselineisparent.md
@@ -1,9 +1,0 @@
-Contender commit `abc` had 2 regressions compared to its baseline commit.
-
-### Benchmarks with regressions:
-
-- Run ID [some_contender1](https://conbench/some_baseline1...some_contender1)
-  - `snappy, nyctaxi_sample, parquet, arrow`
-
-- Run ID [some_contender2](https://conbench/some_baseline2...some_contender2)
-  - `snappy, nyctaxi_sample, parquet, arrow`

--- a/tests/unit_tests/expected_md/summary_workflow_regressions.md
+++ b/tests/unit_tests/expected_md/summary_workflow_regressions.md
@@ -2,7 +2,7 @@ Contender commit `abc` had 1 regressions compared to its baseline commit.
 
 ### Benchmarks with regressions:
 
-- Run ID [some_contender](https://conbench.biz/api/compare/runs/some_baseline...some_contender)
+- Run ID [some_contender](http://localhost/compare/runs/some_baseline...some_contender/)
   - `snappy, nyctaxi_sample, parquet, arrow`
 
 ### Note

--- a/tests/unit_tests/mocked_responses/GET_conbench_runs_contender_wo_base.json
+++ b/tests/unit_tests/mocked_responses/GET_conbench_runs_contender_wo_base.json
@@ -9,7 +9,7 @@
             "message": "ARROW-11771: [Developer][Archery] Move benchmark tests (so CI runs them)",
             "parent_sha": "4beb514d071c9beec69b8917b5265e77ade22fb3",
             "repository": "https://github.com/apache/arrow",
-            "sha": "02addad336ba19a654f9c857ede546331be7b631",
+            "sha": "no_baseline",
             "timestamp": "2021-02-25T01:02:51",
             "url": "https://github.com/apache/arrow/commit/02addad336ba19a654f9c857ede546331be7b631"
         },

--- a/tests/unit_tests/mocked_responses/GET_conbench_runs_some_contender.json
+++ b/tests/unit_tests/mocked_responses/GET_conbench_runs_some_contender.json
@@ -9,7 +9,7 @@
             "message": "ARROW-11771: [Developer][Archery] Move benchmark tests (so CI runs them)",
             "parent_sha": "4beb514d071c9beec69b8917b5265e77ade22fb3",
             "repository": "https://github.com/apache/arrow",
-            "sha": "02addad336ba19a654f9c857ede546331be7b631",
+            "sha": "abc",
             "timestamp": "2021-02-25T01:02:51",
             "url": "https://github.com/apache/arrow/commit/02addad336ba19a654f9c857ede546331be7b631"
         },

--- a/tests/unit_tests/test_clients.py
+++ b/tests/unit_tests/test_clients.py
@@ -16,7 +16,12 @@ import pytest
 import requests
 from _pytest.logging import LogCaptureFixture
 
-from benchalerts.clients import ConbenchClient, GitHubRepoClient
+from benchalerts.clients import (
+    CheckStatus,
+    ConbenchClient,
+    GitHubRepoClient,
+    StatusState,
+)
 
 from .mocks import MockAdapter
 
@@ -48,7 +53,7 @@ class TestGitHubRepoClient:
             commit_sha="abc",
             title="tests",
             description="Testing something",
-            state=self.gh.StatusState.SUCCESS,
+            state=StatusState.SUCCESS,
             details_url="https://conbench.biz/",
         )
         assert res["description"] == "Testing something"
@@ -68,11 +73,7 @@ class TestGitHubRepoClient:
         res = self.gh.update_check(
             name="tests",
             commit_sha="abc",
-            status=(
-                self.gh.CheckStatus.IN_PROGRESS
-                if in_progress
-                else self.gh.CheckStatus.SUCCESS
-            ),
+            status=CheckStatus.IN_PROGRESS if in_progress else CheckStatus.SUCCESS,
             title="This was good",
             summary="Testing something",
             details="Some details",
@@ -110,29 +111,6 @@ class TestConbenchClient:
     def test_conbench_fails_missing_env(self, missing_conbench_env):
         with pytest.raises(ValueError, match="CONBENCH_URL"):
             self.cb
-
-    @pytest.mark.parametrize("z_score_threshold", [None, 500])
-    def test_get_comparison_to_baseline(self, conbench_env, z_score_threshold):
-        comparisons = self.cb.get_comparison_to_baseline("abc", z_score_threshold)
-        assert isinstance(comparisons, list)
-        assert len(comparisons) == 1
-        assert comparisons[0].compare_link
-        assert len(comparisons[0].compare_info) == 2
-
-    def test_comparison_fails_when_no_runs(self, conbench_env):
-        with pytest.raises(ValueError, match="runs"):
-            self.cb.get_comparison_to_baseline("no_runs")
-
-    def test_comparison_warns_when_no_baseline(
-        self, conbench_env, caplog: LogCaptureFixture
-    ):
-        comparisons = self.cb.get_comparison_to_baseline("no_baseline")
-        assert isinstance(comparisons, list)
-        assert len(comparisons) == 1
-        assert comparisons[0].contender_link
-        assert not comparisons[0].compare_link
-        assert not comparisons[0].baseline_info
-        assert "could not find a baseline run" in caplog.text
 
     @pytest.mark.parametrize("path", ["/error_with_content", "/error_without_content"])
     def test_client_error_handling(self, conbench_env, path, caplog: LogCaptureFixture):

--- a/tests/unit_tests/test_parse_conbench.py
+++ b/tests/unit_tests/test_parse_conbench.py
@@ -16,8 +16,9 @@ import pathlib
 from copy import deepcopy
 
 import pytest
+from _pytest.fixtures import SubRequest
 
-from benchalerts.clients import GitHubRepoClient
+from benchalerts.clients import ConbenchClient, GitHubRepoClient
 from benchalerts.parse_conbench import (
     benchmarks_with_z_regressions,
     regression_check_status,
@@ -28,17 +29,64 @@ from benchalerts.parse_conbench import (
 from .mocks import MockResponse, response_dir
 
 
-def mock_comparisons(include_regressions: bool):
-    if include_regressions:
-        compare_json = "GET_conbench_compare_runs_some_baseline_some_contender.json"
-    else:
-        compare_json = "GET_conbench_compare_runs_some_baseline_some_contender_threshold_z_500.json"
-    compare_file = response_dir / compare_json
-    comparisons = MockResponse.from_file(compare_file).json()
-    return {
-        "https://conbench/some_baseline1...some_contender1": deepcopy(comparisons),
-        "https://conbench/some_baseline2...some_contender2": deepcopy(comparisons),
-    }
+@pytest.fixture
+def mock_comparisons(request: SubRequest):
+    how: str = request.param
+
+    def _response(basename: str):
+        filename = basename + ".json"
+        return MockResponse.from_file(response_dir / filename).json()
+
+    contender_info = _response("GET_conbench_runs_some_contender")
+    contender_info_2 = deepcopy(contender_info)
+    contender_info_2["id"] += "_2"
+
+    baseline_info = _response("GET_conbench_runs_some_baseline")
+    baseline_info_2 = deepcopy(baseline_info)
+    baseline_info_2["id"] += "_2"
+
+    no_baseline_info = _response("GET_conbench_runs_contender_wo_base")
+    no_baseline_info_2 = deepcopy(contender_info)
+    no_baseline_info_2["id"] += "_2"
+
+    compare_info_noregressions = _response(
+        "GET_conbench_compare_runs_some_baseline_some_contender_threshold_z_500"
+    )
+    compare_info_regressions = _response(
+        "GET_conbench_compare_runs_some_baseline_some_contender"
+    )
+
+    if how == "noregressions":
+        return [
+            ConbenchClient.RunComparison(
+                contender_info=contender_info,
+                baseline_info=baseline_info,
+                compare_info=compare_info_noregressions,
+            ),
+            ConbenchClient.RunComparison(
+                contender_info=contender_info_2,
+                baseline_info=baseline_info_2,
+                compare_info=compare_info_noregressions,
+            ),
+        ]
+    elif how == "regressions":
+        return [
+            ConbenchClient.RunComparison(
+                contender_info=contender_info,
+                baseline_info=baseline_info,
+                compare_info=compare_info_regressions,
+            ),
+            ConbenchClient.RunComparison(
+                contender_info=contender_info_2,
+                baseline_info=baseline_info_2,
+                compare_info=compare_info_regressions,
+            ),
+        ]
+    elif how == "no_baseline":
+        return [
+            ConbenchClient.RunComparison(contender_info=no_baseline_info),
+            ConbenchClient.RunComparison(contender_info=no_baseline_info_2),
+        ]
 
 
 def get_expected_markdown(filename: str) -> str:
@@ -49,45 +97,45 @@ def get_expected_markdown(filename: str) -> str:
         return f.read()
 
 
-@pytest.mark.parametrize("include_regressions", [False, True])
-def test_benchmarks_with_z_regressions(include_regressions):
-    if include_regressions:
-        expected = [
-            (
-                "https://conbench/some_baseline1...some_contender1",
-                "snappy, nyctaxi_sample, parquet, arrow",
-            ),
-            (
-                "https://conbench/some_baseline2...some_contender2",
-                "snappy, nyctaxi_sample, parquet, arrow",
-            ),
-        ]
-    else:
-        expected = []
-
-    actual = benchmarks_with_z_regressions(mock_comparisons(include_regressions))
+@pytest.mark.parametrize(
+    ["mock_comparisons", "expected"],
+    [
+        ("noregressions", []),
+        (
+            "regressions",
+            [
+                (
+                    "some_contender",
+                    "http://localhost/compare/runs/some_baseline...some_contender/",
+                    "snappy, nyctaxi_sample, parquet, arrow",
+                ),
+                (
+                    "some_contender_2",
+                    "http://localhost/compare/runs/some_baseline_2...some_contender_2/",
+                    "snappy, nyctaxi_sample, parquet, arrow",
+                ),
+            ],
+        ),
+        ("no_baseline", []),
+    ],
+    indirect=["mock_comparisons"],
+)
+def test_benchmarks_with_z_regressions(mock_comparisons, expected):
+    actual = benchmarks_with_z_regressions(mock_comparisons)
     assert actual == expected
 
 
 @pytest.mark.parametrize(
-    ["comparisons", "baseline_is_parent", "expected_md"],
+    ["mock_comparisons", "expected_md"],
     [
-        (mock_comparisons(False), False, "summary_noregressions_baselineisnotparent"),
-        (mock_comparisons(False), True, "summary_noregressions_baselineisparent"),
-        (mock_comparisons(True), False, "summary_regressions_baselineisnotparent"),
-        (mock_comparisons(True), True, "summary_regressions_baselineisparent"),
-        ({}, False, "summary_nobaseline"),
-        ({}, True, "summary_nobaseline"),
+        ("noregressions", "summary_noregressions_baselineisnotparent"),
+        ("regressions", "summary_regressions_baselineisnotparent"),
+        ("no_baseline", "summary_nobaseline"),
     ],
+    indirect=["mock_comparisons"],
 )
-def test_regression_summary(comparisons, baseline_is_parent, expected_md):
-    contender_sha = "abc" if comparisons else "no_baseline"
-    actual = regression_summary(
-        comparisons,
-        baseline_is_parent,
-        contender_sha,
-        warn_if_baseline_isnt_parent=True,
-    )
+def test_regression_summary(mock_comparisons, expected_md):
+    actual = regression_summary(mock_comparisons, warn_if_baseline_isnt_parent=True)
     expected = get_expected_markdown(expected_md)
     assert (
         actual.strip() == expected.strip()
@@ -95,15 +143,16 @@ def test_regression_summary(comparisons, baseline_is_parent, expected_md):
 
 
 @pytest.mark.parametrize(
-    ["comparisons", "expected_md"],
+    ["mock_comparisons", "expected_md"],
     [
-        (mock_comparisons(False), "details_noregressions"),
-        (mock_comparisons(True), "details_regressions"),
-        ({}, None),
+        ("noregressions", "details_noregressions"),
+        ("regressions", "details_regressions"),
+        ("no_baseline", None),
     ],
+    indirect=["mock_comparisons"],
 )
-def test_regression_details(comparisons, expected_md):
-    actual = regression_details(comparisons)
+def test_regression_details(mock_comparisons, expected_md):
+    actual = regression_details(mock_comparisons)
     expected = get_expected_markdown(expected_md)
     if expected:
         assert (
@@ -114,12 +163,13 @@ def test_regression_details(comparisons, expected_md):
 
 
 @pytest.mark.parametrize(
-    ["comparisons", "expected_status"],
+    ["mock_comparisons", "expected_status"],
     [
-        (mock_comparisons(False), GitHubRepoClient.CheckStatus.SUCCESS),
-        (mock_comparisons(True), GitHubRepoClient.CheckStatus.FAILURE),
-        ({}, GitHubRepoClient.CheckStatus.SKIPPED),
+        ("noregressions", GitHubRepoClient.CheckStatus.SUCCESS),
+        ("regressions", GitHubRepoClient.CheckStatus.FAILURE),
+        ("no_baseline", GitHubRepoClient.CheckStatus.SKIPPED),
     ],
+    indirect=["mock_comparisons"],
 )
-def test_regression_check_status(comparisons, expected_status):
-    assert regression_check_status(comparisons) == expected_status
+def test_regression_check_status(mock_comparisons, expected_status):
+    assert regression_check_status(mock_comparisons) == expected_status

--- a/tests/unit_tests/test_talk_to_conbench.py
+++ b/tests/unit_tests/test_talk_to_conbench.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2022, Voltron Data.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from _pytest.logging import LogCaptureFixture
+
+from benchalerts.clients import ConbenchClient
+from benchalerts.talk_to_conbench import get_comparison_to_baseline
+
+from .mocks import MockAdapter
+
+
+@pytest.fixture
+def conbench(conbench_env):
+    return ConbenchClient(adapter=MockAdapter())
+
+
+@pytest.mark.parametrize("z_score_threshold", [None, 500])
+def test_get_comparison_to_baseline(conbench, z_score_threshold):
+    comparisons = get_comparison_to_baseline(conbench, "abc", z_score_threshold)
+    assert isinstance(comparisons, list)
+    assert len(comparisons) == 1
+    assert comparisons[0].compare_link
+    assert len(comparisons[0].compare_results) == 2
+
+
+def test_comparison_fails_when_no_runs(conbench):
+    with pytest.raises(ValueError, match="runs"):
+        get_comparison_to_baseline(conbench, "no_runs")
+
+
+def test_comparison_warns_when_no_baseline(conbench, caplog: LogCaptureFixture):
+    comparisons = get_comparison_to_baseline(conbench, "no_baseline")
+    assert isinstance(comparisons, list)
+    assert len(comparisons) == 1
+    assert comparisons[0].contender_link
+    assert not comparisons[0].compare_link
+    assert not comparisons[0].baseline_info
+    assert "could not find a baseline run" in caplog.text


### PR DESCRIPTION
In preparation for #20 I realized the previous output of `get_comparison_to_baseline()` hides many things we'd like to access when creating reports. This PR changes the output to output almost everything about all the contender runs, in a tidy little class instead of a dict, so it's easier to manage.

This PR fixes #22 .