### PR TITLE
Added benchmark errors to markdown

### DIFF
--- a/benchalerts/_version.py
+++ b/benchalerts/_version.py
@@ -15,4 +15,4 @@
 
 # Please do not add anything else to this file except __version__
 
-__version__ = "0.3.2"
+__version__ = "0.4.0"

--- a/benchalerts/parse_conbench.py
+++ b/benchalerts/parse_conbench.py
@@ -24,7 +24,9 @@ def _clean(text: str) -> str:
     return textwrap.fill(textwrap.dedent(text), 10000).replace("  ", "\n\n").strip()
 
 
-def benchmarks_with_errors(comparisons: List[RunComparison]) -> List[Tuple[str, str]]:
+def benchmarks_with_errors(
+    comparisons: List[RunComparison],
+) -> List[Tuple[str, str, str, str]]:
     """Find the run IDs, webapp links, display names, and error messages of benchmark
     cases that had errors."""
     out = []

--- a/benchalerts/parse_conbench.py
+++ b/benchalerts/parse_conbench.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import textwrap
-from typing import List, Tuple
+from dataclasses import dataclass
+from typing import List
 
 from .clients import CheckStatus
 from .talk_to_conbench import RunComparison
@@ -24,60 +25,92 @@ def _clean(text: str) -> str:
     return textwrap.fill(textwrap.dedent(text), 10000).replace("  ", "\n\n").strip()
 
 
-def benchmarks_with_errors(
-    comparisons: List[RunComparison],
-) -> List[Tuple[str, str, str, str]]:
-    """Find the run IDs, webapp links, display names, and case URLs of benchmark
-    cases that had errors."""
+@dataclass
+class _CaseInfo:
+    run_id: str
+    run_reason: str
+    run_time: str
+    run_link: str
+    case_name: str
+    case_link: str
+
+    @property
+    def Run_Reason(self):
+        return self.run_reason.title()
+
+
+def _list_cases(case_infos: List[_CaseInfo]) -> str:
+    """Create a Markdown list of case information."""
+    out = ""
+    previous_run_id = ""
+
+    for case in case_infos:
+        if case.run_id != previous_run_id:
+            out += f"\n\n- {case.Run_Reason} Run at [{case.run_time}]({case.run_link})"
+            previous_run_id = case.run_id
+        out += f"\n  - [{case.case_name}]({case.case_link})"
+
+    if out:
+        out += "\n\n"
+
+    return out
+
+
+def benchmarks_with_errors(comparisons: List[RunComparison]) -> List[_CaseInfo]:
+    """Find information about benchmark cases that had errors."""
     out = []
 
     for comparison in comparisons:
         if comparison.compare_results:
             out += [
-                (
-                    comparison.contender_id,
-                    comparison.compare_link,
-                    case["benchmark"],
-                    comparison.case_link(case["contender_id"]),
+                _CaseInfo(
+                    run_id=comparison.contender_id,
+                    run_reason=comparison.contender_reason,
+                    run_time=comparison.contender_datetime,
+                    run_link=comparison.compare_link,
+                    case_name=case["benchmark"],
+                    case_link=comparison.case_link(case["contender_id"]),
                 )
                 for case in comparison.compare_results
                 if case["contender_error"]
             ]
-        else:
+        elif comparison.benchmark_results:
             out += [
-                (
-                    comparison.contender_id,
-                    comparison.contender_link,
-                    case["tags"].get("name", str(case["tags"])),
-                    comparison.case_link(case["id"]),
+                _CaseInfo(
+                    run_id=comparison.contender_id,
+                    run_reason=comparison.contender_reason,
+                    run_time=comparison.contender_datetime,
+                    run_link=comparison.contender_link,
+                    case_name=case["tags"].get("name", str(case["tags"])),
+                    case_link=comparison.case_link(case["id"]),
                 )
-                for case in comparison.benchmark_results or []
+                for case in comparison.benchmark_results
                 if case["error"]
             ]
 
     return out
 
 
-def benchmarks_with_z_regressions(
-    comparisons: List[RunComparison],
-) -> List[Tuple[str, str, str, str]]:
-    """Find the run IDs, webapp links, display names, and case URLs of benchmark
-    cases whose z-scores were extreme enough to constitute a regression.
+def benchmarks_with_z_regressions(comparisons: List[RunComparison]) -> List[_CaseInfo]:
+    """Find information about benchmark cases whose z-scores were extreme enough to
+    constitute a regression.
     """
     out = []
 
     for comparison in comparisons:
-        compare_results = comparison.compare_results or []
-        out += [
-            (
-                comparison.contender_id,
-                comparison.compare_link,
-                case["benchmark"],
-                comparison.case_link(case["contender_id"]),
-            )
-            for case in compare_results
-            if case["contender_z_regression"]
-        ]
+        if comparison.compare_results:
+            out += [
+                _CaseInfo(
+                    run_id=comparison.contender_id,
+                    run_reason=comparison.contender_reason,
+                    run_time=comparison.contender_datetime,
+                    run_link=comparison.compare_link,
+                    case_name=case["benchmark"],
+                    case_link=comparison.case_link(case["contender_id"]),
+                )
+                for case in comparison.compare_results
+                if case["contender_z_regression"]
+            ]
 
     return out
 
@@ -101,13 +134,7 @@ def regression_summary(
             benchmark, which might have more information about what the error was.
             """
         )
-        previous_run_id = ""
-        for run_id, run_url, name, error_url in errors:
-            if run_id != previous_run_id:
-                summary += f"\n\n- Run ID [{run_id}]({run_url})"
-                previous_run_id = run_id
-            summary += f"\n  - `{name}` ([link]({error_url}))"
-        summary += "\n\n"
+        summary += _list_cases(errors)
 
     summary += "## Benchmarks with performance regressions\n\n"
 
@@ -124,25 +151,21 @@ def regression_summary(
 
     summary += _clean(
         f"""
-        Contender commit `{sha}` had {len(regressions)} performance regressions compared
-        to its baseline commit.
+        Contender commit `{sha}` had {len(regressions)} performance regression(s)
+        compared to its baseline commit.
         """
     )
+    summary += "\n\n"
 
     if regressions:
-        summary += "\n\n### Benchmarks with regressions:"
-        previous_compare_url = ""
-        for run_id, compare_url, benchmark, case_url in regressions:
-            if compare_url != previous_compare_url:
-                summary += f"\n\n- Run ID [{run_id}]({compare_url})"
-                previous_compare_url = compare_url
-            summary += f"\n  - `{benchmark}` ([link]({case_url}))"
+        summary += "### Benchmarks with regressions:"
+        summary += _list_cases(regressions)
 
     if (
         any(not comparison.baseline_is_parent for comparison in comparisons)
         and warn_if_baseline_isnt_parent
     ):
-        summary += "\n\n" + _clean(
+        summary += _clean(
             """
             ### Note
 
@@ -161,7 +184,7 @@ def regression_details(comparisons: List[RunComparison]) -> str:
 
     z_score_threshold = comparisons[0].compare_results[0]["threshold_z"]
     details = _clean(
-        f"""\
+        f"""
         Conbench has details about {len(comparisons)} total run(s) on this commit.
 
         This report was generated using a z-score threshold of {z_score_threshold}. A
@@ -176,7 +199,7 @@ def regression_details(comparisons: List[RunComparison]) -> str:
 def regression_check_status(
     comparisons: List[RunComparison],
 ) -> CheckStatus:
-    """Return a different status based on regressions."""
+    """Return a different status based on errors and regressions."""
     regressions = benchmarks_with_z_regressions(comparisons)
 
     if any(comparison.has_errors for comparison in comparisons):

--- a/benchalerts/talk_to_conbench.py
+++ b/benchalerts/talk_to_conbench.py
@@ -38,11 +38,18 @@ class RunComparison:
         /compare/runs/{baseline_run_id}...{contender_run_id}, if a baseline run exists
         for this contender run. Contains a comparison for every case run to its
         baseline, including the statistics and regression analysis.
+    benchmark_results
+        The list returned from Conbench when hitting
+        /benchmarks?run_id={contender_run_id}, if the contender run has errors. Contains
+        info about each case in the contender run, including statistics and tracebacks.
+        Only used when a baseline run doesn't exist, because otherwise all this
+        information is already in the compare_results.
     """
 
     contender_info: dict
     baseline_info: Optional[dict] = None
     compare_results: Optional[List[dict]] = None
+    benchmark_results: Optional[List[dict]] = None
 
     @property
     def baseline_is_parent(self) -> Optional[bool]:
@@ -159,6 +166,11 @@ def get_comparison_to_baseline(
                 "same repository, with the same hardware and context, and have at "
                 "least one of the same benchmark cases."
             )
+            if run_comparison.contender_info["has_errors"]:
+                # get more information so we have more details about errors
+                run_comparison.benchmark_results = conbench.get(
+                    "/benchmarks/", params={"run_id": run_id}
+                )
 
         out_list.append(run_comparison)
 

--- a/benchalerts/talk_to_conbench.py
+++ b/benchalerts/talk_to_conbench.py
@@ -74,6 +74,15 @@ class RunComparison:
             # self._compare_path has a leading slash already
             return f"{self._app_url}{self._compare_path}"
 
+    def case_link(self, case_id: str) -> str:
+        """Get the link to a specific benchmark case result in the webapp."""
+        return f"{self._app_url}/benchmarks/{case_id}"
+
+    @property
+    def has_errors(self) -> bool:
+        """Whether this run has any benchmark errors."""
+        return self.contender_info["has_errors"]
+
     @property
     def contender_id(self) -> str:
         """The contender run_id."""
@@ -166,7 +175,7 @@ def get_comparison_to_baseline(
                 "same repository, with the same hardware and context, and have at "
                 "least one of the same benchmark cases."
             )
-            if run_comparison.contender_info["has_errors"]:
+            if run_comparison.has_errors:
                 # get more information so we have more details about errors
                 run_comparison.benchmark_results = conbench.get(
                     "/benchmarks/", params={"run_id": run_id}

--- a/benchalerts/talk_to_conbench.py
+++ b/benchalerts/talk_to_conbench.py
@@ -63,6 +63,17 @@ class RunComparison:
             )
 
     @property
+    def contender_reason(self) -> str:
+        """The contender run reason."""
+        return self.contender_info["reason"]
+
+    @property
+    def contender_datetime(self) -> str:
+        """The contender run datetime."""
+        dt: str = self.contender_info["timestamp"]
+        return dt.replace("T", " ")
+
+    @property
     def contender_link(self) -> str:
         """The link to the contender run page in the webapp."""
         return f"{self._app_url}/runs/{self.contender_id}"

--- a/tests/integration_tests/test_talk_to_conbench_integration.py
+++ b/tests/integration_tests/test_talk_to_conbench_integration.py
@@ -42,6 +42,13 @@ from benchalerts.talk_to_conbench import get_comparison_to_baseline
             1,
             None,
         ),
+        # errors
+        (
+            "https://conbench.ursa.dev",
+            "9fa34df27eb1445ac11b0ab0298d421b04be80f7",
+            7,
+            True,
+        ),
     ],
 )
 def test_get_comparison_to_baseline(

--- a/tests/unit_tests/expected_md/summary_nobaseline.md
+++ b/tests/unit_tests/expected_md/summary_nobaseline.md
@@ -1,9 +1,10 @@
-# Benchmark errors
+## Benchmarks with errors
 
-- Run ID [some_contender](http://localhost/runs/some_contender)
-  - `file-write`
-    - `Something went wrong`
+These are errors that were caught while running the benchmarks. You can click the link next to each case to go to the Conbench entry for that benchmark, which might have more information about what the error was.
 
-# Regression analysis
+- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
+  - [file-write](http://localhost/benchmarks/some-benchmark-uuid-2)
+
+## Benchmarks with performance regressions
 
 Conbench could not find a baseline run for contender commit `no_basel`. A baseline run needs to be on the default branch in the same repository, with the same hardware and context, and have at least one of the same benchmark cases.

--- a/tests/unit_tests/expected_md/summary_nobaseline.md
+++ b/tests/unit_tests/expected_md/summary_nobaseline.md
@@ -1,1 +1,9 @@
+# Benchmark errors
+
+- Run ID [some_contender](http://localhost/runs/some_contender)
+  - `file-write`
+    - `Something went wrong`
+
+# Regression analysis
+
 Conbench could not find a baseline run for contender commit `no_basel`. A baseline run needs to be on the default branch in the same repository, with the same hardware and context, and have at least one of the same benchmark cases.

--- a/tests/unit_tests/expected_md/summary_noregressions.md
+++ b/tests/unit_tests/expected_md/summary_noregressions.md
@@ -1,16 +1,16 @@
-# Benchmark errors
+## Benchmarks with errors
 
-- Run ID [some_contender](http://localhost/compare/runs/some_baseline...some_contender/)
-  - `snappy, nyctaxi_sample, csv, arrow`
-    - `Something went wrong`
+These are errors that were caught while running the benchmarks. You can click the link next to each case to go to the Conbench entry for that benchmark, which might have more information about what the error was.
 
-- Run ID [some_contender_2](http://localhost/compare/runs/some_baseline_2...some_contender_2/)
-  - `snappy, nyctaxi_sample, csv, arrow`
-    - `Something went wrong`
+- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
+  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmarks/some-benchmark-uuid-4)
 
-# Regression analysis
+- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline_2...some_contender_2/)
+  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmarks/some-benchmark-uuid-4)
 
-Contender commit `abc` had 0 regressions compared to its baseline commit.
+## Benchmarks with performance regressions
+
+Contender commit `abc` had 0 performance regression(s) compared to its baseline commit.
 
 ### Note
 

--- a/tests/unit_tests/expected_md/summary_noregressions.md
+++ b/tests/unit_tests/expected_md/summary_noregressions.md
@@ -4,6 +4,10 @@
   - `snappy, nyctaxi_sample, csv, arrow`
     - `Something went wrong`
 
+- Run ID [some_contender_2](http://localhost/compare/runs/some_baseline_2...some_contender_2/)
+  - `snappy, nyctaxi_sample, csv, arrow`
+    - `Something went wrong`
+
 # Regression analysis
 
 Contender commit `abc` had 0 regressions compared to its baseline commit.

--- a/tests/unit_tests/expected_md/summary_noregressions_baselineisnotparent.md
+++ b/tests/unit_tests/expected_md/summary_noregressions_baselineisnotparent.md
@@ -1,5 +1,0 @@
-Contender commit `abc` had 0 regressions compared to its baseline commit.
-
-### Note
-
-The baseline commit was not the immediate parent of the contender commit. See the link below for details.

--- a/tests/unit_tests/expected_md/summary_noregressions_baselineisparent.md
+++ b/tests/unit_tests/expected_md/summary_noregressions_baselineisparent.md
@@ -1,1 +1,0 @@
-Contender commit `abc` had 0 regressions compared to its baseline commit.

--- a/tests/unit_tests/expected_md/summary_regressions.md
+++ b/tests/unit_tests/expected_md/summary_regressions.md
@@ -1,24 +1,24 @@
-# Benchmark errors
+## Benchmarks with errors
 
-- Run ID [some_contender](http://localhost/compare/runs/some_baseline...some_contender/)
-  - `snappy, nyctaxi_sample, csv, arrow`
-    - `Something went wrong`
+These are errors that were caught while running the benchmarks. You can click the link next to each case to go to the Conbench entry for that benchmark, which might have more information about what the error was.
 
-- Run ID [some_contender_2](http://localhost/compare/runs/some_baseline_2...some_contender_2/)
-  - `snappy, nyctaxi_sample, csv, arrow`
-    - `Something went wrong`
+- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
+  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmarks/some-benchmark-uuid-4)
 
-# Regression analysis
+- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline_2...some_contender_2/)
+  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmarks/some-benchmark-uuid-4)
 
-Contender commit `abc` had 2 regressions compared to its baseline commit.
+## Benchmarks with performance regressions
+
+Contender commit `abc` had 2 performance regression(s) compared to its baseline commit.
 
 ### Benchmarks with regressions:
 
-- Run ID [some_contender](http://localhost/compare/runs/some_baseline...some_contender/)
-  - `snappy, nyctaxi_sample, parquet, arrow`
+- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
+  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/benchmarks/some-benchmark-uuid-3)
 
-- Run ID [some_contender_2](http://localhost/compare/runs/some_baseline_2...some_contender_2/)
-  - `snappy, nyctaxi_sample, parquet, arrow`
+- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline_2...some_contender_2/)
+  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/benchmarks/some-benchmark-uuid-3)
 
 ### Note
 

--- a/tests/unit_tests/expected_md/summary_regressions.md
+++ b/tests/unit_tests/expected_md/summary_regressions.md
@@ -1,3 +1,15 @@
+# Benchmark errors
+
+- Run ID [some_contender](http://localhost/compare/runs/some_baseline...some_contender/)
+  - `snappy, nyctaxi_sample, csv, arrow`
+    - `Something went wrong`
+
+- Run ID [some_contender_2](http://localhost/compare/runs/some_baseline_2...some_contender_2/)
+  - `snappy, nyctaxi_sample, csv, arrow`
+    - `Something went wrong`
+
+# Regression analysis
+
 Contender commit `abc` had 2 regressions compared to its baseline commit.
 
 ### Benchmarks with regressions:

--- a/tests/unit_tests/expected_md/summary_workflow_noregressions.md
+++ b/tests/unit_tests/expected_md/summary_workflow_noregressions.md
@@ -1,12 +1,13 @@
-# Benchmark errors
+## Benchmarks with errors
 
-- Run ID [some_contender](http://localhost/compare/runs/some_baseline...some_contender/)
-  - `snappy, nyctaxi_sample, csv, arrow`
-    - `Something went wrong`
+These are errors that were caught while running the benchmarks. You can click the link next to each case to go to the Conbench entry for that benchmark, which might have more information about what the error was.
 
-# Regression analysis
+- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
+  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmarks/some-benchmark-uuid-4)
 
-Contender commit `abc` had 0 regressions compared to its baseline commit.
+## Benchmarks with performance regressions
+
+Contender commit `abc` had 0 performance regression(s) compared to its baseline commit.
 
 ### Note
 

--- a/tests/unit_tests/expected_md/summary_workflow_regressions.md
+++ b/tests/unit_tests/expected_md/summary_workflow_regressions.md
@@ -1,3 +1,11 @@
+# Benchmark errors
+
+- Run ID [some_contender](http://localhost/compare/runs/some_baseline...some_contender/)
+  - `snappy, nyctaxi_sample, csv, arrow`
+    - `Something went wrong`
+
+# Regression analysis
+
 Contender commit `abc` had 1 regressions compared to its baseline commit.
 
 ### Benchmarks with regressions:

--- a/tests/unit_tests/expected_md/summary_workflow_regressions.md
+++ b/tests/unit_tests/expected_md/summary_workflow_regressions.md
@@ -1,17 +1,18 @@
-# Benchmark errors
+## Benchmarks with errors
 
-- Run ID [some_contender](http://localhost/compare/runs/some_baseline...some_contender/)
-  - `snappy, nyctaxi_sample, csv, arrow`
-    - `Something went wrong`
+These are errors that were caught while running the benchmarks. You can click the link next to each case to go to the Conbench entry for that benchmark, which might have more information about what the error was.
 
-# Regression analysis
+- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
+  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmarks/some-benchmark-uuid-4)
 
-Contender commit `abc` had 1 regressions compared to its baseline commit.
+## Benchmarks with performance regressions
+
+Contender commit `abc` had 1 performance regression(s) compared to its baseline commit.
 
 ### Benchmarks with regressions:
 
-- Run ID [some_contender](http://localhost/compare/runs/some_baseline...some_contender/)
-  - `snappy, nyctaxi_sample, parquet, arrow`
+- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
+  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/benchmarks/some-benchmark-uuid-3)
 
 ### Note
 

--- a/tests/unit_tests/mocked_responses/GET_conbench_benchmarks_run_id_contender_wo_base.json
+++ b/tests/unit_tests/mocked_responses/GET_conbench_benchmarks_run_id_contender_wo_base.json
@@ -1,0 +1,114 @@
+{
+    "status_code": 200,
+    "data": [
+        {
+            "batch_id": "some-batch-uuid-1",
+            "error": null,
+            "id": "some-benchmark-uuid-1",
+            "links": {
+                "context": "http://localhost/api/contexts/some-context-uuid-1/",
+                "info": "http://localhost/api/info/some-info-uuid-1/",
+                "list": "http://localhost/api/benchmarks/",
+                "run": "http://localhost/api/runs/some-run-uuid-1/",
+                "self": "http://localhost/api/benchmarks/some-benchmark-uuid-1/"
+            },
+            "run_id": "some-run-uuid-1",
+            "stats": {
+                "data": [
+                    0.099094,
+                    0.037129,
+                    0.036381,
+                    0.148896,
+                    0.008104,
+                    0.005496,
+                    0.009871,
+                    0.006008,
+                    0.007978,
+                    0.004733
+                ],
+                "iqr": 0.030442,
+                "iterations": 10,
+                "max": 0.148896,
+                "mean": 0.036369,
+                "median": 0.008988,
+                "min": 0.004733,
+                "q1": 0.0065,
+                "q3": 0.036942,
+                "stdev": 0.049194,
+                "time_unit": "s",
+                "times": [
+                    0.099094,
+                    0.037129,
+                    0.036381,
+                    0.148896,
+                    0.008104,
+                    0.005496,
+                    0.009871,
+                    0.006008,
+                    0.007978,
+                    0.004733
+                ],
+                "unit": "s",
+                "z_improvement": false,
+                "z_regression": false,
+                "z_score": null
+            },
+            "tags": {
+                "compression": "snappy",
+                "cpu_count": 2,
+                "dataset": "nyctaxi_sample",
+                "file_type": "parquet",
+                "id": "some-case-uuid-1",
+                "input_type": "arrow",
+                "name": "file-read"
+            },
+            "timestamp": "2020-11-25T21:02:42.706806"
+        },
+        {
+            "batch_id": "some-batch-uuid-1",
+            "error": {
+                "fatal": true,
+                "message": "Something went wrong",
+                "regression": false,
+                "stack_trace": "Traceback (most recent call last):\n  File \"<stdin>\", line 1, in <module>\nAssertionError"
+            },
+            "id": "some-benchmark-uuid-2",
+            "links": {
+                "context": "http://localhost/api/contexts/some-context-uuid-1/",
+                "info": "http://localhost/api/info/some-info-uuid-1/",
+                "list": "http://localhost/api/benchmarks/",
+                "run": "http://localhost/api/runs/some-run-uuid-1/",
+                "self": "http://localhost/api/benchmarks/some-benchmark-uuid-2/"
+            },
+            "run_id": "some-run-uuid-1",
+            "stats": {
+                "data": [],
+                "iqr": null,
+                "iterations": null,
+                "max": null,
+                "mean": null,
+                "median": null,
+                "min": null,
+                "q1": null,
+                "q3": null,
+                "stdev": null,
+                "time_unit": null,
+                "times": [],
+                "unit": null,
+                "z_improvement": false,
+                "z_regression": false,
+                "z_score": null
+            },
+            "tags": {
+                "compression": "snappy",
+                "cpu_count": 2,
+                "dataset": "nyctaxi_sample",
+                "file_type": "parquet",
+                "id": "some-case-uuid-2",
+                "input_type": "arrow",
+                "name": "file-write"
+            },
+            "timestamp": "2020-11-25T21:03:42.706806"
+        }
+    ]
+}

--- a/tests/unit_tests/mocked_responses/GET_conbench_compare_runs_some_baseline_some_contender.json
+++ b/tests/unit_tests/mocked_responses/GET_conbench_compare_runs_some_baseline_some_contender.json
@@ -51,7 +51,12 @@
             "change": "0.000%",
             "contender": "0.036 s",
             "contender_batch_id": "some-batch-uuid-2",
-            "contender_error": null,
+            "contender_error": {
+                "fatal": true,
+                "message": "Something went wrong",
+                "regression": false,
+                "stack_trace": "Traceback (most recent call last):\n  File \"<stdin>\", line 1, in <module>\nAssertionError"
+            },
             "contender_id": "some-benchmark-uuid-4",
             "contender_run_id": "some-run-uuid-2",
             "contender_z_improvement": false,

--- a/tests/unit_tests/mocked_responses/GET_conbench_compare_runs_some_baseline_some_contender_threshold_z_500.json
+++ b/tests/unit_tests/mocked_responses/GET_conbench_compare_runs_some_baseline_some_contender_threshold_z_500.json
@@ -51,7 +51,12 @@
             "change": "0.000%",
             "contender": "0.036 s",
             "contender_batch_id": "some-batch-uuid-2",
-            "contender_error": null,
+            "contender_error": {
+                "fatal": true,
+                "message": "Something went wrong",
+                "regression": false,
+                "stack_trace": "Traceback (most recent call last):\n  File \"<stdin>\", line 1, in <module>\nAssertionError"
+            },
             "contender_id": "some-benchmark-uuid-4",
             "contender_run_id": "some-run-uuid-2",
             "contender_z_improvement": false,

--- a/tests/unit_tests/mocked_responses/GET_conbench_runs_contender_wo_base.json
+++ b/tests/unit_tests/mocked_responses/GET_conbench_runs_contender_wo_base.json
@@ -36,7 +36,7 @@
             "os_version": "10.15.7",
             "type": "machine"
         },
-        "has_errors": false,
+        "has_errors": true,
         "id": "some_contender",
         "links": {
             "baseline": null,

--- a/tests/unit_tests/test_parse_conbench.py
+++ b/tests/unit_tests/test_parse_conbench.py
@@ -48,15 +48,14 @@ def mock_comparisons(request: SubRequest):
 
     contender_info, contender_info_2 = _dup_info("GET_conbench_runs_some_contender")
     baseline_info, baseline_info_2 = _dup_info("GET_conbench_runs_some_baseline")
-    no_baseline_info, no_baseline_info_2 = _dup_info(
-        "GET_conbench_runs_contender_wo_base"
-    )
+    no_baseline_info = _response("GET_conbench_runs_contender_wo_base")
     compare_results_noregressions = _response(
         "GET_conbench_compare_runs_some_baseline_some_contender_threshold_z_500"
     )
     compare_results_regressions = _response(
         "GET_conbench_compare_runs_some_baseline_some_contender"
     )
+    benchmark_results = _response("GET_conbench_benchmarks_run_id_contender_wo_base")
 
     if how == "noregressions":
         return [
@@ -86,8 +85,9 @@ def mock_comparisons(request: SubRequest):
         ]
     elif how == "no_baseline":
         return [
-            RunComparison(contender_info=no_baseline_info),
-            RunComparison(contender_info=no_baseline_info_2),
+            RunComparison(
+                contender_info=no_baseline_info, benchmark_results=benchmark_results
+            ),
         ]
 
 
@@ -130,8 +130,8 @@ def test_benchmarks_with_z_regressions(mock_comparisons, expected):
 @pytest.mark.parametrize(
     ["mock_comparisons", "expected_md"],
     [
-        ("noregressions", "summary_noregressions_baselineisnotparent"),
-        ("regressions", "summary_regressions_baselineisnotparent"),
+        ("noregressions", "summary_noregressions"),
+        ("regressions", "summary_regressions"),
         ("no_baseline", "summary_nobaseline"),
     ],
     indirect=["mock_comparisons"],

--- a/tests/unit_tests/test_talk_to_conbench.py
+++ b/tests/unit_tests/test_talk_to_conbench.py
@@ -47,4 +47,5 @@ def test_comparison_warns_when_no_baseline(conbench, caplog: LogCaptureFixture):
     assert comparisons[0].contender_link
     assert not comparisons[0].compare_link
     assert not comparisons[0].baseline_info
+    assert len(comparisons[0].benchmark_results) == 2
     assert "could not find a baseline run" in caplog.text


### PR DESCRIPTION
Fixes #20 . This PR adds a list of erroring benchmark cases on the contender commit to the Markdown report.

I also realized that we don't have access to the errors if we don't have a baseline run (because we don't have run comparison info), so I added some code to query the benchmark results for the run in that case.